### PR TITLE
[#2] Add Support for Default Values

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -261,3 +261,47 @@ func TestLoadWithInvalidFloat(t *testing.T) {
 	// Assert
 	assert.NotNil(t, err)
 }
+
+func TestLoadWithDefaultString(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value string `env:"TEST_VALUE,default=Hello"`
+	}
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+
+	// Assert
+	assert.Nil(t, err)
+	assert.Equal(t, "Hello", s.Value)
+}
+
+func TestLoadWithDefaultInt(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value int `env:"TEST_VALUE,default=5"`
+	}
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+
+	// Assert
+	assert.Nil(t, err)
+	assert.Equal(t, 5, s.Value)
+}
+
+func TestLoadWithDefaultMissingValue(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value string `env:"TEST_VALUE,default"`
+	}
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+
+	// Assert
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
# Overview

This PR adds support for default values if no other value was found. Example:

```go
type S struct {
    V string `env:"VALUE,default=Hello!"`
}

var s S
err := minienv.Load(&s)

print(s.V) // Hello!
```

## Checklist

- [x] Tests
- [x] Documentation - will be done in #4 

## Related Tasks

<!-- Link the task that is related to this if applicable. If not, remove this section. -->

* #2 
