### PR TITLE
[NO-ISSUE] Optimize Error Handling

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  layout: "header, files, condensed_footer"

--- a/env.go
+++ b/env.go
@@ -78,7 +78,7 @@ func handleStruct(s reflect.Value, overrides map[string]string) error {
 
 		// something went wrong parsing the tag
 		if err != nil {
-			return TagParsingError{
+			return LoadError{
 				Field: s.Type().Field(i).Name,
 				Err:   err,
 			}
@@ -86,7 +86,7 @@ func handleStruct(s reflect.Value, overrides map[string]string) error {
 
 		// check if we can actually set the field
 		if !field.IsValid() || !field.CanSet() {
-			return FieldError{
+			return LoadError{
 				Field: s.Type().Field(i).Name,
 				Err:   errors.New("field is not valid or cannot be set"),
 			}
@@ -98,7 +98,7 @@ func handleStruct(s reflect.Value, overrides map[string]string) error {
 
 		// guard against the cases where we don't have any valeu that we can set
 		if !envExists && !overrideExists && tag.required && tag.defaultValue == "" {
-			return FieldError{
+			return LoadError{
 				Field: s.Type().Field(i).Name,
 				Err:   errors.New("required field has no value and no default"),
 			}
@@ -121,9 +121,8 @@ func handleStruct(s reflect.Value, overrides map[string]string) error {
 		err = setField(field, val)
 		if err != nil {
 			// we wrap the error for some metadata
-			return CoversionError{
+			return LoadError{
 				Field: s.Type().Field(i).Name,
-				Value: val,
 				Err:   err,
 			}
 		}
@@ -202,7 +201,7 @@ func parseTag(field reflect.StructField) (tag, bool, error) {
 
 			// if we have more or less than 2 elements we have an invalid tag
 			if len(splitted) != 2 {
-				return tag{}, true, errors.New("default tag does not contain a single value")
+				return tag{}, true, errors.New("invalid default tag")
 			}
 
 			defaultVal = splitted[1]

--- a/errors.go
+++ b/errors.go
@@ -6,36 +6,13 @@ import "fmt"
 
 var ErrInvalidInput = fmt.Errorf("input struct is not a struct or a pointer to one")
 
-// GENERAL ERROR
+// Loading Error
 
-type FieldError struct {
+type LoadError struct {
 	Field string
 	Err   error
 }
 
-func (e FieldError) Error() string {
-	return fmt.Sprintf("error for field \"%s\": %s", e.Field, e.Err.Error())
-}
-
-// PARSING ERROR
-
-type TagParsingError struct {
-	Field string
-	Err   error
-}
-
-func (e TagParsingError) Error() string {
-	return fmt.Sprintf("failed to parse tag for field %s: %s", e.Field, e.Err.Error())
-}
-
-// CONVERSION ERROR
-
-type CoversionError struct {
-	Field string
-	Value string
-	Err   error
-}
-
-func (e CoversionError) Error() string {
-	return fmt.Sprintf("failed to convert value %s for field \"%s\" to target type: %s", e.Value, e.Field, e.Err.Error())
+func (e LoadError) Error() string {
+	return fmt.Sprintf("failed to load field \"%s\": %s", e.Field, e.Err.Error())
 }


### PR DESCRIPTION
# Overview

This PR optimizes the error handling by reducing the multiple custom errors down to a single `LoadError` that represent an error when loading a single field within the struct. Additionally a new test case was added to cover private fields that fail the `CanSet()`-check.

## Checklist

- [x] Tests
- [x] Documentation -> Will be done by #4 
