### PR TITLE
[NO-ISSUE] Fixed Missing Nested Value Handled Incorrectly

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: "5"
+
 comment:
   layout: "header, files, condensed_footer"

--- a/env.go
+++ b/env.go
@@ -73,7 +73,11 @@ func handleStruct(s reflect.Value, config *LoadConfig) error {
 		// handle recursive cases
 		field := s.Field(i)
 		if field.Kind() == reflect.Struct {
-			handleStruct(field, config)
+			err := handleStruct(field, config)
+			if err != nil {
+				return err
+			}
+
 			continue
 		}
 

--- a/env_test.go
+++ b/env_test.go
@@ -188,6 +188,26 @@ func TestLoadWithMissingValue(t *testing.T) {
 	assert.ErrorContains(t, missingErr, "required field has no value and no default")
 }
 
+func TestLoadWithMissingNestedValue(t *testing.T) {
+	// Arrange
+	type S struct {
+		N struct {
+			Value string `env:"TEST_VALUE"`
+		}
+	}
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+
+	// Assert
+	assert.Error(t, err)
+
+	missingErr := err.(minienv.LoadError)
+	assert.Equal(t, "Value", missingErr.Field)
+	assert.ErrorContains(t, missingErr, "required field has no value and no default")
+}
+
 func TestLoadWithUnsupportedType(t *testing.T) {
 	// Arrange
 	type S struct {


### PR DESCRIPTION
# Overview

This PR fixes a small bug where missing nested values are handled incorrectly and don't return an error. This was due to a missing `err` check and return.

## Checklist

- [x] Tests
- [x] Documentation