### PR TITLE
[#15] Add `golangci-lint`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig for Go and YAML files
+root = true
+
+# Go files
+[*.go]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# YAML files
+[*.yml]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yaml]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,18 @@
+name: Checks
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: Linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+
+      - name: Golangci-lint
+        uses: golangci/golangci-lint-action@v8.0.0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,5 @@ linters:
   default: standard
   enable:
     - errname
-    - paralleltest
     - testpackage
     - whitespace

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,8 @@
+version: "2"
+linters:
+  default: standard
+  enable:
+    - errname
+    - paralleltest
+    - testpackage
+    - whitespace

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,17 @@
 {
-    "go.lintOnSave": "package",
-    "go.formatTool": "goimports",
-    "go.useLanguageServer": true,
-    "gopls": {
-        "ui.diagnostic.staticcheck": true
-    }
+    // LINTING
+    "go.lintOnSave": "workspace",
+    "go.lintTool": "golangci-lint",
+    "go.lintFlags": [
+        "--path-mode=abs",
+    ],
+    // FORMATTING
+    "go.formatTool": "custom",
+    "go.alternateTools": {
+        "customFormatter": "golangci-lint"
+    },
+    "go.formatFlags": [
+        "fmt",
+        "--stdin"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "go.lintOnSave": "workspace",
     "go.lintTool": "golangci-lint",
     "go.lintFlags": [
-        "--path-mode=abs",
+        "--path-mode=abs"
     ],
     // FORMATTING
     "go.formatTool": "custom",

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,9 @@ coverage:
     project:
       default:
         threshold: "5"
+    patch:
+      default:
+        threshold: "50"
 
 comment:
   layout: "header, files, condensed_footer"

--- a/env_test.go
+++ b/env_test.go
@@ -1,7 +1,6 @@
 package minienv_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,8 +14,7 @@ func TestLoadWithString(t *testing.T) {
 		Value string `env:"TEST_VALUE"`
 	}
 
-	os.Setenv("TEST_VALUE", "test-string")
-	defer os.Unsetenv("TEST_VALUE")
+	setenv(t, "TEST_VALUE", "test-string")
 
 	// Act
 	var s S
@@ -33,8 +31,7 @@ func TestLoadWithInt(t *testing.T) {
 		Value int `env:"TEST_VALUE"`
 	}
 
-	os.Setenv("TEST_VALUE", "3823992")
-	defer os.Unsetenv("TEST_VALUE")
+	setenv(t, "TEST_VALUE", "3823992")
 
 	// Act
 	var s S
@@ -51,8 +48,7 @@ func TestLoadWithFloat(t *testing.T) {
 		Value float64 `env:"TEST_VALUE"`
 	}
 
-	os.Setenv("TEST_VALUE", "34.3243")
-	defer os.Unsetenv("TEST_VALUE")
+	setenv(t, "TEST_VALUE", "34.3243")
 
 	// Act
 	var s S
@@ -69,8 +65,7 @@ func TestLoadWithBool(t *testing.T) {
 		Value bool `env:"TEST_VALUE"`
 	}
 
-	os.Setenv("TEST_VALUE", "true")
-	defer os.Unsetenv("TEST_VALUE")
+	setenv(t, "TEST_VALUE", "true")
 
 	// Act
 	var s S
@@ -89,8 +84,7 @@ func TestLoadWithSingleNested(t *testing.T) {
 		}
 	}
 
-	os.Setenv("TEST_VALUE", "test")
-	defer os.Unsetenv("TEST_VALUE")
+	setenv(t, "TEST_VALUE", "test")
 
 	// Act
 	var s S
@@ -109,11 +103,8 @@ func TestLoadWithOptional(t *testing.T) {
 		OptEx string `env:"OPT_EX,optional"` // is optional and set
 	}
 
-	os.Setenv("REQ", "required")
-	defer os.Unsetenv("REQ")
-
-	os.Setenv("OPT_EX", "optionalexists")
-	defer os.Unsetenv("OPT_EX")
+	setenv(t, "REQ", "required")
+	setenv(t, "OPT_EX", "optionalexists")
 
 	// Act
 	var s S
@@ -158,8 +149,7 @@ func TestLoadWithMixedTags(t *testing.T) {
 		NotTagged string
 	}
 
-	os.Setenv("TEST_VALUE", "test-value")
-	defer os.Unsetenv("TEST_VALUE")
+	setenv(t, "TEST_VALUE", "test-value")
 
 	// Act
 	var s S
@@ -215,8 +205,7 @@ func TestLoadWithUnsupportedType(t *testing.T) {
 		Value map[string]string `env:"TEST_VALUE"`
 	}
 
-	os.Setenv("TEST_VALUE", "test-value")
-	defer os.Unsetenv("TEST_VALUE")
+	setenv(t, "TEST_VALUE", "test-value")
 
 	// Act
 	var s S
@@ -236,8 +225,7 @@ func TestLoadWithInvalidInt(t *testing.T) {
 		Value int `env:"TEST_VALUE"`
 	}
 
-	os.Setenv("TEST_VALUE", "test-value")
-	defer os.Unsetenv("TEST_VALUE")
+	setenv(t, "TEST_VALUE", "test-value")
 
 	// Act
 	var s S
@@ -257,8 +245,7 @@ func TestLoadWithInvalidBool(t *testing.T) {
 		Value bool `env:"TEST_VALUE"`
 	}
 
-	os.Setenv("TEST_VALUE", "test-value")
-	defer os.Unsetenv("TEST_VALUE")
+	setenv(t, "TEST_VALUE", "test-value")
 
 	// Act
 	var s S
@@ -278,8 +265,7 @@ func TestLoadWithInvalidFloat(t *testing.T) {
 		Value float64 `env:"TEST_VALUE"`
 	}
 
-	os.Setenv("TEST_VALUE", "test-value")
-	defer os.Unsetenv("TEST_VALUE")
+	setenv(t, "TEST_VALUE", "test-value")
 
 	// Act
 	var s S
@@ -350,8 +336,7 @@ func TestLoadWithUnsettableField(t *testing.T) {
 		_ string `env:"TEST_VALUE"`
 	}
 
-	os.Setenv("TEST_VALUE", "test-value")
-	defer os.Unsetenv("TEST_VALUE")
+	setenv(t, "TEST_VALUE", "test-value")
 
 	// Act
 	var s S
@@ -368,8 +353,7 @@ func TestLoadWithSplittableFloatField(t *testing.T) {
 		FloatDefaults []float64 `env:"TEST_FLOATS_DEF,split=,,default=[1.1,2.2,3.3]"`
 	}
 
-	os.Setenv("TEST_FLOATS", "1.1,2.2,3.3")
-	defer os.Unsetenv("TEST_FLOATS")
+	setenv(t, "TEST_FLOATS", "1.1,2.2,3.3")
 
 	// Act
 	var s S
@@ -387,8 +371,7 @@ func TestLoadWithSplittableStringField(t *testing.T) {
 		StrDefault []string `env:"TEST_STR_DEF,split=,,default=[test1,test2]"`
 	}
 
-	os.Setenv("TEST_STR", "test1,test2")
-	defer os.Unsetenv("TEST_STR")
+	setenv(t, "TEST_STR", "test1,test2")
 
 	// Act
 	var s S
@@ -406,8 +389,7 @@ func TestLoadWithSplittableIntField(t *testing.T) {
 		NumbersDefault []int `env:"TEST_NUMBERS_DEF,split=,,default=[1,2,3]"`
 	}
 
-	os.Setenv("TEST_NUMBERS", "1,2,3")
-	defer os.Unsetenv("TEST_NUMBERS")
+	setenv(t, "TEST_NUMBERS", "1,2,3")
 
 	// Act
 	var s S
@@ -425,8 +407,7 @@ func TestLoadWithSplittableBoolField(t *testing.T) {
 		BoolsDefault []bool `env:"TEST_BOOLS_DEF,split=,,default=[true,false]"`
 	}
 
-	os.Setenv("TEST_BOOLS", "true,false")
-	defer os.Unsetenv("TEST_BOOLS")
+	setenv(t, "TEST_BOOLS", "true,false")
 
 	// Act
 	var s S
@@ -443,8 +424,7 @@ func TestLoadWithSplittableUnsupportedType(t *testing.T) {
 		Unsupported []struct{} `env:"TEST_UNSUPPORTED,split=,"`
 	}
 
-	os.Setenv("TEST_UNSUPPORTED", "test1,test2")
-	defer os.Unsetenv("TEST_UNSUPPORTED")
+	setenv(t, "TEST_UNSUPPORTED", "test1,test2")
 
 	// Act
 	var s S

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,22 @@
+package minienv_test
+
+import (
+	"os"
+	"testing"
+)
+
+func setenv(t *testing.T, key, value string) {
+	t.Helper()
+
+	err := os.Setenv(key, value)
+	if err != nil {
+		t.Fatalf("Failed to set environment variable %s: %v", key, err)
+	}
+
+	t.Cleanup(func() {
+		err := os.Unsetenv(key)
+		if err != nil {
+			t.Errorf("Failed to unset environment variable %s: %v", key, err)
+		}
+	})
+}

--- a/internal/tag/parser_test.go
+++ b/internal/tag/parser_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestParseEnvTagWithCompleteValidOptions(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type testCase struct {
 		name     string
@@ -70,6 +72,8 @@ func TestParseEnvTagWithCompleteValidOptions(t *testing.T) {
 }
 
 func TestParseEnvTagWithInvalidOptions(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type testCase struct {
 		name          string
@@ -106,6 +110,8 @@ func TestParseEnvTagWithInvalidOptions(t *testing.T) {
 // TESTS RELATED TO THE SPLIT OPTION
 
 func TestParseEnvTagWithValidSplitOptions(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type testCase struct {
 		name     string
@@ -174,6 +180,8 @@ func TestParseEnvTagWithValidSplitOptions(t *testing.T) {
 }
 
 func TestParseEnvTagWithInvalidSplitOptions(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type testCase struct {
 		name          string
@@ -214,6 +222,8 @@ func TestParseEnvTagWithInvalidSplitOptions(t *testing.T) {
 
 // TESTS RELATED TO THE DEFAULT OPTION
 func TestParseEnvTagWithValidDefaultOptions(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type testCase struct {
 		name     string
@@ -281,6 +291,8 @@ func TestParseEnvTagWithValidDefaultOptions(t *testing.T) {
 }
 
 func TestParseEnvTagWithInvalidDefaultOptions(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type testCase struct {
 		name          string

--- a/options.go
+++ b/options.go
@@ -2,6 +2,8 @@ package minienv
 
 import (
 	"bufio"
+	"log"
+	"maps"
 	"os"
 	"regexp"
 )
@@ -11,9 +13,7 @@ import (
 // The keys are case-sensitive.
 func WithFallbackValues(values map[string]string) Option {
 	return func(c *LoadConfig) error {
-		for k, v := range values {
-			c.Values[k] = v
-		}
+		maps.Copy(c.Values, values)
 
 		return nil
 	}
@@ -36,9 +36,7 @@ func WithFile(required bool, files ...string) Option {
 			return err
 		}
 
-		for k, v := range values {
-			c.Values[k] = v
-		}
+		maps.Copy(c.Values, values)
 
 		return nil
 	}
@@ -62,9 +60,7 @@ func readEnvFiles(shouldRaiseError bool, files ...string) (map[string]string, er
 			continue
 		}
 
-		for k, v := range envs {
-			values[k] = v
-		}
+		maps.Copy(values, envs)
 	}
 
 	return values, nil
@@ -76,7 +72,11 @@ func parseEnvFile(path string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Printf("Failed to close env file %s: %v", path, err)
+		}
+	}()
 
 	overrides := map[string]string{}
 

--- a/options_test.go
+++ b/options_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 func TestWithFallbackValues(t *testing.T) {
-	t.Parallel()
-
 	// Arrange
 	type S struct {
 		FromFallback string `env:"FROM_FALLBACK"`
@@ -39,8 +37,6 @@ func TestWithFallbackValues(t *testing.T) {
 }
 
 func TestWithFile(t *testing.T) {
-	t.Parallel()
-
 	// Arrange
 	type S struct {
 		Value string `env:"FROM_FILE"`
@@ -64,8 +60,6 @@ func TestWithFile(t *testing.T) {
 }
 
 func TestWithFileAndQuoted(t *testing.T) {
-	t.Parallel()
-
 	// Arrange
 	type S struct {
 		Double string `env:"DOUBLE"`
@@ -92,8 +86,6 @@ func TestWithFileAndQuoted(t *testing.T) {
 }
 
 func TestWithFileAndMissingOptionalFile(t *testing.T) {
-	t.Parallel()
-
 	// Arrange
 	type S struct {
 		Value string `env:"VALUE"`
@@ -113,8 +105,6 @@ func TestWithFileAndMissingOptionalFile(t *testing.T) {
 }
 
 func TestWithFileAndMissingRequiredFile(t *testing.T) {
-	t.Parallel()
-
 	// Arrange
 	type S struct {
 		Value string `env:"VALUE"`
@@ -131,8 +121,6 @@ func TestWithFileAndMissingRequiredFile(t *testing.T) {
 }
 
 func TestWithFileAndRequired(t *testing.T) {
-	t.Parallel()
-
 	// Arrange
 	type S struct {
 		Value string `env:"VALUE"`
@@ -155,8 +143,6 @@ func TestWithFileAndRequired(t *testing.T) {
 }
 
 func TestWithFileAndDefaultFile(t *testing.T) {
-	t.Parallel()
-
 	// Arrange
 	type S struct {
 		Value string `env:"VALUE"`
@@ -179,8 +165,6 @@ func TestWithFileAndDefaultFile(t *testing.T) {
 }
 
 func TestWithMultipleFiles(t *testing.T) {
-	t.Parallel()
-
 	// Arrange
 	type S struct {
 		One string `env:"ONE"`
@@ -211,8 +195,6 @@ func TestWithMultipleFiles(t *testing.T) {
 }
 
 func TestWithEmptyLines(t *testing.T) {
-	t.Parallel()
-
 	// Arrange
 	type S struct {
 		Value string `env:"VAL"`
@@ -237,8 +219,6 @@ func TestWithEmptyLines(t *testing.T) {
 }
 
 func TestWithPrefix(t *testing.T) {
-	t.Parallel()
-
 	// Arrange
 	type S struct {
 		Value string `env:"VALUE"`

--- a/options_test.go
+++ b/options_test.go
@@ -1,7 +1,6 @@
 package minienv_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +8,8 @@ import (
 )
 
 func TestWithFallbackValues(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type S struct {
 		FromFallback string `env:"FROM_FALLBACK"`
@@ -18,11 +19,8 @@ func TestWithFallbackValues(t *testing.T) {
 		FromBoth string `env:"FROM_BOTH"`
 	}
 
-	os.Setenv("FROM_ENV", "from-env")
-	defer os.Unsetenv("FROM_ENV")
-
-	os.Setenv("FROM_BOTH", "from-both-env")
-	defer os.Unsetenv("FROM_BOTH")
+	setenv(t, "FROM_ENV", "from-env")
+	setenv(t, "FROM_BOTH", "from-both-env")
 
 	values := map[string]string{
 		"FROM_FALLBACK": "from-fallback",
@@ -41,6 +39,8 @@ func TestWithFallbackValues(t *testing.T) {
 }
 
 func TestWithFile(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type S struct {
 		Value string `env:"FROM_FILE"`
@@ -64,6 +64,8 @@ func TestWithFile(t *testing.T) {
 }
 
 func TestWithFileAndQuoted(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type S struct {
 		Double string `env:"DOUBLE"`
@@ -90,6 +92,8 @@ func TestWithFileAndQuoted(t *testing.T) {
 }
 
 func TestWithFileAndMissingOptionalFile(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type S struct {
 		Value string `env:"VALUE"`
@@ -97,8 +101,7 @@ func TestWithFileAndMissingOptionalFile(t *testing.T) {
 
 	filename := "test.env" // file does not exist
 
-	os.Setenv("VALUE", "val")
-	defer os.Unsetenv("VALUE")
+	setenv(t, "VALUE", "val")
 
 	// Act
 	var s S
@@ -110,6 +113,8 @@ func TestWithFileAndMissingOptionalFile(t *testing.T) {
 }
 
 func TestWithFileAndMissingRequiredFile(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type S struct {
 		Value string `env:"VALUE"`
@@ -126,6 +131,8 @@ func TestWithFileAndMissingRequiredFile(t *testing.T) {
 }
 
 func TestWithFileAndRequired(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type S struct {
 		Value string `env:"VALUE"`
@@ -148,6 +155,8 @@ func TestWithFileAndRequired(t *testing.T) {
 }
 
 func TestWithFileAndDefaultFile(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type S struct {
 		Value string `env:"VALUE"`
@@ -170,6 +179,8 @@ func TestWithFileAndDefaultFile(t *testing.T) {
 }
 
 func TestWithMultipleFiles(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type S struct {
 		One string `env:"ONE"`
@@ -200,6 +211,8 @@ func TestWithMultipleFiles(t *testing.T) {
 }
 
 func TestWithEmptyLines(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type S struct {
 		Value string `env:"VAL"`
@@ -224,13 +237,14 @@ func TestWithEmptyLines(t *testing.T) {
 }
 
 func TestWithPrefix(t *testing.T) {
+	t.Parallel()
+
 	// Arrange
 	type S struct {
 		Value string `env:"VALUE"`
 	}
 
-	os.Setenv("PREFIX_VALUE", "test-value")
-	defer os.Unsetenv("PREFIX_VALUE")
+	setenv(t, "PREFIX_VALUE", "test-value")
 
 	// Act
 	var s S


### PR DESCRIPTION
# Overview

This PR adds `golangci-lint` to the project instead of using `staticcheck`. This will greatly improve the amount of issues that we can catch before things go into production.

## Checklist

- [ ] Tests
- [ ] Documentation

## Related Tasks

<!-- Link the task that is related to this if applicable. If not, remove this section. -->

* #15 
