### PR TITLE
[#27] Fix Float & Int Parsing

### DIFF
--- a/env.go
+++ b/env.go
@@ -116,6 +116,32 @@ func fetchFieldValue(config *LoadConfig, tag tag) (string, error) {
 	return val, nil
 }
 
+// return the bit size for the given int kind, or 0 if it's not an int kind
+func intBitSize(k reflect.Kind) int {
+	switch k {
+	case reflect.Int8:
+		return 8
+	case reflect.Int16:
+		return 16
+	case reflect.Int32:
+		return 32
+	case reflect.Int64:
+		return 64
+	default:
+		return 0
+	}
+}
+
+// return the bit size for the given float kind, or 0 if it's not a float kind
+func floatBitSize(k reflect.Kind) int {
+	switch k {
+	case reflect.Float32:
+		return 32
+	default:
+		return 64
+	}
+}
+
 // Sets a field based on the kind and the provided value
 func set(f reflect.Value, val string) error {
 	k := f.Kind()
@@ -126,12 +152,13 @@ func set(f reflect.Value, val string) error {
 
 	// int
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		i, err := strconv.Atoi(val)
+		bitSize := intBitSize(k)
+		i, err := strconv.ParseInt(val, 10, bitSize)
 		if err != nil {
 			return err
 		}
 
-		f.SetInt(int64(i))
+		f.SetInt(i)
 
 	// bool
 	case reflect.Bool:
@@ -144,7 +171,8 @@ func set(f reflect.Value, val string) error {
 
 	// float
 	case reflect.Float32, reflect.Float64:
-		fl, err := strconv.ParseFloat(val, 64)
+		bitSize := floatBitSize(k)
+		fl, err := strconv.ParseFloat(val, bitSize)
 		if err != nil {
 			return err
 		}

--- a/env.go
+++ b/env.go
@@ -116,7 +116,7 @@ func fetchFieldValue(config *LoadConfig, tag tag) (string, error) {
 	return val, nil
 }
 
-// return the bit size for the given int kind, or 0 if it's not an int kind
+// return the bit size for the given int kind, or 0 if it's just a regular int
 func intBitSize(k reflect.Kind) int {
 	switch k {
 	case reflect.Int8:
@@ -132,7 +132,7 @@ func intBitSize(k reflect.Kind) int {
 	}
 }
 
-// return the bit size for the given float kind, or 0 if it's not a float kind
+// return the bit size for the given float kind
 func floatBitSize(k reflect.Kind) int {
 	switch k {
 	case reflect.Float32:

--- a/env_test.go
+++ b/env_test.go
@@ -41,6 +41,171 @@ func TestLoadWithInt(t *testing.T) {
 	assert.Equal(t, 3823992, s.Value)
 }
 
+func TestLoadWithInt8(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value int8 `env:"TEST_VALUE"`
+	}
+
+	setenv(t, "TEST_VALUE", "127")
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+	assert.NoError(t, err)
+
+	// Assert
+	assert.Equal(t, int8(127), s.Value)
+}
+
+func TestLoadWithInt8Overflow(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value int8 `env:"TEST_VALUE"`
+	}
+
+	setenv(t, "TEST_VALUE", "128")
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+
+	// Assert
+	assert.Error(t, err)
+
+	conversionErr := err.(minienv.FieldError)
+	assert.Equal(t, "Value", conversionErr.Field)
+	assert.ErrorContains(t, conversionErr, "out of range")
+}
+
+func TestLoadWithInt16(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value int16 `env:"TEST_VALUE"`
+	}
+
+	setenv(t, "TEST_VALUE", "32767")
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+	assert.NoError(t, err)
+
+	// Assert
+	assert.Equal(t, int16(32767), s.Value)
+}
+
+func TestLoadWithInt16Overflow(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value int16 `env:"TEST_VALUE"`
+	}
+
+	setenv(t, "TEST_VALUE", "32768")
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+
+	// Assert
+	assert.Error(t, err)
+
+	conversionErr := err.(minienv.FieldError)
+	assert.Equal(t, "Value", conversionErr.Field)
+	assert.ErrorContains(t, conversionErr, "out of range")
+}
+
+func TestLoadWithInt32(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value int32 `env:"TEST_VALUE"`
+	}
+
+	setenv(t, "TEST_VALUE", "2147483647")
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+	assert.NoError(t, err)
+
+	// Assert
+	assert.Equal(t, int32(2147483647), s.Value)
+}
+
+func TestLoadWithInt32Overflow(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value int32 `env:"TEST_VALUE"`
+	}
+
+	setenv(t, "TEST_VALUE", "2147483648")
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+
+	// Assert
+	assert.Error(t, err)
+
+	conversionErr := err.(minienv.FieldError)
+	assert.Equal(t, "Value", conversionErr.Field)
+	assert.ErrorContains(t, conversionErr, "out of range")
+}
+
+func TestLoadWithInt64(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value int64 `env:"TEST_VALUE"`
+	}
+
+	setenv(t, "TEST_VALUE", "9223372036854775807")
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+	assert.NoError(t, err)
+
+	// Assert
+	assert.Equal(t, int64(9223372036854775807), s.Value)
+}
+
+func TestLoadWithFloat32(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value float32 `env:"TEST_VALUE"`
+	}
+
+	setenv(t, "TEST_VALUE", "3.14")
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+	assert.NoError(t, err)
+
+	// Assert
+	assert.InDelta(t, float32(3.14), s.Value, 0.001)
+}
+
+func TestLoadWithFloat32Overflow(t *testing.T) {
+	// Arrange
+	type S struct {
+		Value float32 `env:"TEST_VALUE"`
+	}
+
+	setenv(t, "TEST_VALUE", "3.4e+39")
+
+	// Act
+	var s S
+	err := minienv.Load(&s)
+
+	// Assert
+	assert.Error(t, err)
+
+	conversionErr := err.(minienv.FieldError)
+	assert.Equal(t, "Value", conversionErr.Field)
+	assert.ErrorContains(t, conversionErr, "out of range")
+}
+
 func TestLoadWithFloat(t *testing.T) {
 	// Arrange
 	type S struct {
@@ -271,7 +436,7 @@ func TestLoadWithInvalidInt(t *testing.T) {
 
 	conversionErr := err.(minienv.FieldError)
 	assert.Equal(t, "Value", conversionErr.Field)
-	assert.ErrorContains(t, conversionErr, "strconv.Atoi: parsing \"test-value\": invalid syntax")
+	assert.ErrorContains(t, conversionErr, "strconv.ParseInt: parsing \"test-value\": invalid syntax")
 }
 
 func TestLoadWithInvalidBool(t *testing.T) {
@@ -614,7 +779,7 @@ func TestLoadMapWithWrongValueType(t *testing.T) {
 
 	// Assert
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "failed to set map value for key \"key\": strconv.Atoi: parsing \"value\": invalid syntax")
+	assert.ErrorContains(t, err, "failed to set map value for key \"key\": strconv.ParseInt: parsing \"value\": invalid syntax")
 }
 
 func TestLoadMapWithWrongKeyType(t *testing.T) {
@@ -630,7 +795,7 @@ func TestLoadMapWithWrongKeyType(t *testing.T) {
 
 	// Assert
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "failed to set map key \"key\": strconv.Atoi: parsing \"key\": invalid syntax")
+	assert.ErrorContains(t, err, "failed to set map key \"key\": strconv.ParseInt: parsing \"key\": invalid syntax")
 }
 
 func TestLoadMapWithMissingValue(t *testing.T) {


### PR DESCRIPTION
# Overview

This PR adjusts the parsing of floats and ints by correctly respecting their bit sizes instead of just assuming 64 bits.

## Checklist

- [x] Tests
- [x] Documentation

## Related Tasks

<!-- Link the task that is related to this if applicable. If not, remove this section. -->

* Closes #27
